### PR TITLE
Add compatibility package for uvicorn entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,19 @@ This repository now ships with a working FastAPI backend and a Vite + React (Tai
 
 ## Backend
 
+The backend lives in the `backend/` directory, but thanks to the lightweight
+`app/` compatibility package you can start the API from the repository root.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+uvicorn app.main:app --reload
+```
+
+If you prefer to keep virtual environments scoped to the backend folder, the
+following commands are equivalent:
+
 ```bash
 cd backend
 python -m venv .venv

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,9 @@
+"""Compatibility layer exposing the backend FastAPI app under the ``app`` package.
+
+This allows running ``uvicorn app.main:app`` from the project root, as suggested in
+the README, without restructuring the existing backend package layout.
+"""
+
+from backend.app.main import app  # pragma: no cover
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- add a top-level `app` package that exposes the FastAPI instance from `backend.app.main`
- allow the documented `uvicorn app.main:app --reload` command to work from the repository root