### PR TITLE
Finalize AlgoExpert-style course page layout

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "monaco-editor": "^0.53.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-resizable-panels": "^1.0.7",
         "react-router-dom": "^6.22.1"
       },
       "devDependencies": {
@@ -3976,6 +3977,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-1.0.10.tgz",
+      "integrity": "sha512-0+g0CNqregkuocr+Mi+e6wgWVARnKTYIX3U1QK7GlkLQKCmbymZakx80YGwcRO7HNnKJTQ5v38HlBos/cGxWvg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@monaco-editor/react": "^4.7.0",
     "axios": "^1.6.7",
     "monaco-editor": "^0.53.0",
+    "react-resizable-panels": "^1.0.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.1"

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -5,6 +5,8 @@ export type CodeEditorProps = {
   code: string;
   onChange: (value: string) => void;
   theme: "light" | "dark";
+  height?: string | number;
+  className?: string;
 };
 
 type Monaco = typeof import("monaco-editor");
@@ -50,10 +52,16 @@ const loadMonacoEditor = () => {
   return monacoModulePromise;
 };
 
-const CodeEditor = ({ language, code, onChange, theme }: CodeEditorProps) => {
+const CodeEditor = ({ language, code, onChange, theme, height, className }: CodeEditorProps) => {
   const [monacoModule, setMonacoModule] = useState<MonacoEditorModule | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const editorLanguage = useMemo(() => language.toLowerCase(), [language]);
+  const resolvedHeight = useMemo(() => {
+    if (typeof height === "number") {
+      return `${height}px`;
+    }
+    return height ?? "400px";
+  }, [height]);
 
   useEffect(() => {
     let cancelled = false;
@@ -79,9 +87,12 @@ const CodeEditor = ({ language, code, onChange, theme }: CodeEditorProps) => {
 
   if (!monacoModule) {
     return (
-      <div className="overflow-hidden rounded-2xl border border-slate-200 shadow-sm dark:border-slate-700">
+      <div
+        className={`overflow-hidden rounded-2xl border border-slate-200 shadow-sm dark:border-slate-700 ${className ?? ""}`}
+        style={{ height: resolvedHeight }}
+      >
         <textarea
-          className="h-[400px] w-full resize-none overflow-auto border-0 p-4 font-mono text-sm outline-none focus:ring-2 focus:ring-blue-200 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-blue-500"
+          className="h-full w-full resize-none overflow-auto border-0 p-4 font-mono text-sm outline-none focus:ring-2 focus:ring-blue-200 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-blue-500"
           value={code}
           onChange={(event) => onChange(event.target.value)}
           spellCheck={false}
@@ -98,9 +109,12 @@ const CodeEditor = ({ language, code, onChange, theme }: CodeEditorProps) => {
   const EditorComponent = monacoModule.default;
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-slate-200 shadow-sm dark:border-slate-700">
+    <div
+      className={`overflow-hidden rounded-2xl border border-slate-200 shadow-sm dark:border-slate-700 ${className ?? ""}`}
+      style={{ height: resolvedHeight }}
+    >
       <EditorComponent
-        height="400px"
+        height={resolvedHeight}
         defaultLanguage={editorLanguage}
         language={editorLanguage}
         value={code}


### PR DESCRIPTION
## Summary
- finish wiring the course page into the new AlgoExpert-style layout with resizable lesson, editor, and output panels
- enhance the shared code editor to accept height and className overrides so it can fill the new layout panels
- record the new react-resizable-panels dependency needed for the split-pane experience
https://chatgpt.com/codex/tasks/task_e_68e32b01dfe48325bda0295ef76cd969