### PR TITLE
Revamp course workspace layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Link, Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthProvider, useAuth } from "./context";
 import LoginPage from "./pages/LoginPage";
 import DashboardPage from "./pages/DashboardPage";
@@ -35,31 +35,7 @@ const AdminRoute = ({ children }: { children: JSX.Element }) => {
 
 const PlaygroundWrapper = () => (
   <div className="min-h-screen bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
-    <header className="border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-        <Link to="/" className="flex items-center gap-2 text-lg font-semibold text-slate-900 transition-colors dark:text-white">
-          <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-400 to-sky-500 text-lg font-bold text-white shadow-soft">
-            O
-          </span>
-          <span>Orus School</span>
-        </Link>
-        <div className="flex items-center gap-3 text-sm font-medium text-slate-600 transition-colors dark:text-slate-300">
-          <Link
-            to="/"
-            className="rounded-full px-4 py-2 transition-all hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-white/10 dark:hover:text-white"
-          >
-            Back to site
-          </Link>
-          <Link
-            to="/login"
-            className="rounded-full bg-slate-900 px-4 py-2 text-white shadow-soft transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white/10 dark:text-white dark:hover:bg-white/20"
-          >
-            Sign in
-          </Link>
-        </div>
-      </div>
-    </header>
-    <main className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+    <main className="flex min-h-screen flex-col">
       <CoursePage />
     </main>
   </div>
@@ -80,6 +56,7 @@ const AppRoutes = () => (
     >
       <Route index element={<DashboardPage />} />
       <Route path="courses/:courseId" element={<CoursePage />} />
+      <Route path="courses/:courseId/lesson/:lessonId" element={<CoursePage />} />
       <Route
         path="admin"
         element={

--- a/frontend/src/components/ShellLayout.tsx
+++ b/frontend/src/components/ShellLayout.tsx
@@ -1,9 +1,12 @@
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../context";
 
 const ShellLayout = () => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const isCourseRoute = location.pathname.startsWith("/app/courses");
 
   const handleLogout = () => {
     logout();
@@ -11,32 +14,19 @@ const ShellLayout = () => {
   };
 
   return (
-    <div className="min-h-screen bg-transparent text-slate-900 transition-colors dark:text-slate-100">
-      <header className="sticky top-0 z-30 border-b border-white/20 bg-white/80 backdrop-blur dark:border-slate-800/80 dark:bg-slate-900/70">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-          <div className="flex items-center gap-2 text-xl font-semibold text-slate-900 transition-colors dark:text-white">
-            <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-400 to-sky-500 text-lg font-bold text-white shadow-soft">
-              O
-            </span>
-            <span>Orus School</span>
-          </div>
-          <nav className="flex items-center gap-3 text-sm font-medium text-slate-600 transition-colors dark:text-slate-300">
-            <NavLink
-              to="/app"
-              className={({ isActive }) =>
-                `rounded-full px-4 py-2 transition-all ${
-                  isActive
-                    ? "bg-slate-900 text-white shadow-soft dark:bg-white/10 dark:text-white"
-                    : "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-white/10 dark:hover:text-white"
-                }`
-              }
-              end
-            >
-              Dashboard
-            </NavLink>
-            {user?.role === "admin" ? (
+    <div className="flex min-h-screen flex-col bg-transparent text-slate-900 transition-colors dark:text-slate-100">
+      {!isCourseRoute ? (
+        <header className="sticky top-0 z-30 border-b border-white/20 bg-white/80 backdrop-blur dark:border-slate-800/80 dark:bg-slate-900/70">
+          <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+            <div className="flex items-center gap-2 text-xl font-semibold text-slate-900 transition-colors dark:text-white">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-400 to-sky-500 text-lg font-bold text-white shadow-soft">
+                O
+              </span>
+              <span>Orus School</span>
+            </div>
+            <nav className="flex items-center gap-3 text-sm font-medium text-slate-600 transition-colors dark:text-slate-300">
               <NavLink
-                to="/app/admin"
+                to="/app"
                 className={({ isActive }) =>
                   `rounded-full px-4 py-2 transition-all ${
                     isActive
@@ -44,20 +34,41 @@ const ShellLayout = () => {
                       : "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-white/10 dark:hover:text-white"
                   }`
                 }
+                end
               >
-                Admin
+                Dashboard
               </NavLink>
-            ) : null}
-            <button
-              onClick={handleLogout}
-              className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white/10 dark:text-white dark:hover:bg-white/20"
-            >
-              Log out
-            </button>
-          </nav>
-        </div>
-      </header>
-      <main className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+              {user?.role === "admin" ? (
+                <NavLink
+                  to="/app/admin"
+                  className={({ isActive }) =>
+                    `rounded-full px-4 py-2 transition-all ${
+                      isActive
+                        ? "bg-slate-900 text-white shadow-soft dark:bg-white/10 dark:text-white"
+                        : "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-white/10 dark:hover:text-white"
+                    }`
+                  }
+                >
+                  Admin
+                </NavLink>
+              ) : null}
+              <button
+                onClick={handleLogout}
+                className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white/10 dark:text-white dark:hover:bg-white/20"
+              >
+                Log out
+              </button>
+            </nav>
+          </div>
+        </header>
+      ) : null}
+      <main
+        className={
+          isCourseRoute
+            ? "flex flex-1 flex-col overflow-hidden bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-100"
+            : "mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6 lg:px-8"
+        }
+      >
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- remove the marketing wrapper around the playground route and add support for `/app/courses/:courseId/lesson/:lessonId`
- update the shell layout so the course workspace takes over the viewport while other sections keep the original header framing
- rework the course page to drive lesson selection from the URL, expose a full-width navbar, and stretch the IDE-style panels edge to edge